### PR TITLE
Rename some stuff for clarity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,16 +37,16 @@ and modify the ``html_theme`` setting to:
 Theme options
 +++++++++++++
 
-To enable the Faculty platform docs navigation bar, set the ``navigation``
+To enable the Faculty platform docs navigation bar, set the ``platform_navbar``
 option to ``True``. The navigation bar will, by default, link to the actual
 docs at `<https://docs.faculty.ai/>`_, but this can be overridden with the
-``navigation_root`` setting.
+``platform_navbar_root`` setting.
 
 Example entry in ``conf.py``:
 
 .. code-block:: python
 
     html_theme_options = {
-        "navigation": True,
-        "navigation_root": "/my/local/directory",
+        "platform_navbar": True,
+        "platform_navbar_root": "/my/local/directory",
     }

--- a/faculty_sphinx_theme/layout.html
+++ b/faculty_sphinx_theme/layout.html
@@ -14,14 +14,14 @@
     "https://fonts.googleapis.com/css?family=IBM+Plex+Sans|Roboto:400,700|Roboto+Mono:400,700&display=swap"
 ] %}
 
-{% macro docs_path(document) -%}
-  {{ pathto(theme_navigation_root + document, 1) }}
+{% macro platform_docs_url(document) -%}
+  {{ pathto(theme_platform_navbar_root + document, 1) }}
 {%- endmacro %}
 
 {% block sidebartitle %}
 
-  {% if theme_navigation | tobool %}
-    <a class="heading" href="{{ docs_path('index.html') }}">
+  {% if theme_platform_navbar | tobool %}
+    <a class="heading" href="{{ platform_docs_url('index.html') }}">
       <div class="logo-box">
         <img class="logo" src="{{ pathto('_static/' + logo, 1) }}"/>
       </div>
@@ -56,11 +56,11 @@
 
 {% block content %}
 
-  {% if theme_navigation | tobool %}
+  {% if theme_platform_navbar | tobool %}
     <nav class="platform-docs-navigation">
       <ul>
         <li class="component">
-          <a href="{{ docs_path('user-guide/index.html') }}">User guide</a>
+          <a href="{{ platform_docs_url('user-guide/index.html') }}">User guide</a>
           <!-- Example menu links:
             <ul>
               <li class="section"><a>Section 1</a></li>
@@ -69,7 +69,7 @@
           -->
         </li>
         <li class="component">
-          <a href="{{ docs_path('library/index.html') }}">Python library</a>
+          <a href="{{ platform_docs_url('library/index.html') }}">Python library</a>
         </li>
       </ul>
     </nav>

--- a/faculty_sphinx_theme/layout.html
+++ b/faculty_sphinx_theme/layout.html
@@ -57,7 +57,7 @@
 {% block content %}
 
   {% if theme_platform_navbar | tobool %}
-    <nav class="platform-docs-navigation">
+    <nav class="platform-navbar">
       <ul>
         <li class="component">
           <a href="{{ platform_docs_url('user-guide/index.html') }}">User guide</a>

--- a/faculty_sphinx_theme/static/css/faculty.css
+++ b/faculty_sphinx_theme/static/css/faculty.css
@@ -134,7 +134,7 @@ footer span.commit .rst-content tt {
 }
 
 /* Navigation bar */
-.platform-docs-navigation {
+.platform-navbar {
   margin: -26px -52px 26px;
   width: calc(100vw - 300px);
   line-height: 50px;
@@ -143,25 +143,25 @@ footer span.commit .rst-content tt {
 
 /* Hide navigation bar on small screens */
 @media (max-width: 768px) {
-  .platform-docs-navigation {
+  .platform-navbar {
     display: none;
   }
 }
 
 /* Lay out navigation bar entries */
-.platform-docs-navigation ul {
+.platform-navbar ul {
   display: flex;
   flex: 1;
   transition: .3s;
 }
-.platform-docs-navigation li {
+.platform-navbar li {
   flex: 1;
   position: relative;
   transition: .3s;
   text-align: left;
   max-width: 12rem;
 }
-.platform-docs-navigation .component > ul {
+.platform-navbar .component > ul {
   left: 0;
   top: 100%;
   display: none;
@@ -169,12 +169,12 @@ footer span.commit .rst-content tt {
 }
 
 /* Expand menus on hover */
-.platform-docs-navigation .component:hover > ul {
+.platform-navbar .component:hover > ul {
   display: block;
 }
 
 /* Links in navigation bar */
-.platform-docs-navigation a {
+.platform-navbar a {
   display: block;
   text-align: center; /* Temporary: Remove once menus filled */
   /* padding-left: 1rem; Temporary: Restore once menus filled */
@@ -183,7 +183,7 @@ footer span.commit .rst-content tt {
 
 /* Highlight elements with coral on hover */
 .wy-side-nav-search > a.heading:hover,
-.platform-docs-navigation .component:hover,
-.platform-docs-navigation .section:hover {
+.platform-navbar .component:hover,
+.platform-navbar .section:hover {
   background-color: #fa7268;
 }

--- a/faculty_sphinx_theme/theme.conf
+++ b/faculty_sphinx_theme/theme.conf
@@ -2,5 +2,5 @@
 inherit = sphinx_rtd_theme
 
 [options]
-navigation = False
-navigation_root = https://docs.faculty.ai/
+platform_navbar = False
+platform_navbar_root = https://docs.faculty.ai/


### PR DESCRIPTION
In particular, adopt names of the style 'platform navbar'.