### PR TITLE
stylesheet: add minimum required formatting for functions params rendering

### DIFF
--- a/faculty_sphinx_theme/static/css/faculty.css
+++ b/faculty_sphinx_theme/static/css/faculty.css
@@ -195,3 +195,14 @@ footer span.commit .rst-content tt {
 .platform-navbar .platform-navbar-entry:hover {
   background-color: #fa7268;
 }
+
+/* Function docstring formatting for parameters */
+.classifier {
+  font-style: oblique;
+}
+
+.classifier:before {
+  font-style: normal;
+  margin: 0.5em;
+  content: ":";
+}


### PR DESCRIPTION
Before the parameter name and type is squashed together, with this there's a colon separation and styling.

Before:
<img width="390" alt="Screenshot 2021-06-09 at 11 05 07" src="https://user-images.githubusercontent.com/38863/121336137-22c79980-c913-11eb-8261-ef66491c7f50.png">

After:
<img width="435" alt="Screenshot 2021-06-09 at 11 04 48" src="https://user-images.githubusercontent.com/38863/121336156-2824e400-c913-11eb-91f9-dbc3c9982201.png">

The styling changes are from the `basic` Sphinx theme. In that theme other stylistic changes are implemented as well (such as the "Params" and "Returns" headers spanning the whole side next to the list of parameters and return information). In this PR those are not considered yet, just the minimum amount of readability improvement.
