### PR TITLE
fix search through bumping the underlying RTD theme that fixed the issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=["faculty_sphinx_theme"],
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["sphinx-rtd-theme==0.4.3"],
+    install_requires=["sphinx-rtd-theme==1.0.0"],
     package_data={
         "faculty_sphinx_theme": [
             "theme.conf",


### PR DESCRIPTION
The search issue was due to Sphinx changes and fixed in https://github.com/readthedocs/sphinx_rtd_theme/pull/1021
that was released in the 0.5.1 version of the theme, so that's the earliest we can bump to to have functioning search again.

Looking at versions since then, the latest (1.0.0) version seems to have identical results in the compiled documentation, so
bumping to that version is likely more future proof.